### PR TITLE
Don't use puppet until the fact is evaluated.

### DIFF
--- a/lib/facter/munki_last_run.rb
+++ b/lib/facter/munki_last_run.rb
@@ -1,5 +1,4 @@
 # munki_last_run.rb
-require 'puppet/util/plist' if Puppet.features.cfpropertylist?
 
 # Get the plist dynamically eventually
 report_plist = '/Library/Managed Installs/ManagedInstallReport.plist'
@@ -8,6 +7,7 @@ Facter.add(:munki_last_run) do
   confine kernel: 'Darwin'
   setcode do
     if File.exist?(report_plist)
+      require 'puppet/util/plist' if Puppet.features.cfpropertylist?
       plist = Puppet::Util::Plist.read_plist_file(report_plist)
       last_run = plist['StartTime']
       last_run

--- a/lib/facter/munki_managed_installs.rb
+++ b/lib/facter/munki_managed_installs.rb
@@ -1,12 +1,11 @@
 # munki_managed_installs.rb
 
-require 'puppet/util/plist' if Puppet.features.cfpropertylist?
-
 report_plist = '/Library/Managed Installs/ManagedInstallReport.plist'
 
 Facter.add(:munki_managed_installs) do
   confine kernel: 'Darwin'
   setcode do
+    require 'puppet/util/plist' if Puppet.features.cfpropertylist?
     output = {}
     if File.exist?(report_plist)
       plist = Puppet::Util::Plist.read_plist_file(report_plist)


### PR DESCRIPTION
This fixes facter on some machines (due to the pseudo random load order of facts,
and if you're using facter without puppet loaded - the facts as-is can break things).