### PR TITLE
Support for Munki 3.3.0

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,5 @@
 ---
-munki::munkitools_version: '3.0.3.3352'
+munki::munkitools_version: '3.3.0.3515'
 munki::apple_software_updates_only: false
 munki::client_cert_path: "%{facts.ssldir}/certs/%{facts.certname}.pem"
 munki::client_identifier: ''

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,20 @@
 # Ensure munki's services are running
 class munki::service {
 
+  $post_v3_agents_cmd = '# get console UID
+  consoleuser=`/usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u`
+
+  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
+  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
+  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
+  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist
+  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
+  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
+  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
+  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist
+
+  exit 0'
+
   service { 'com.googlecode.munki.managedsoftwareupdate-check':
     ensure => 'running',
     enable => true,
@@ -16,7 +30,38 @@ class munki::service {
     enable => true,
   }
 
-  -> if versioncmp($facts['munki_version'], '3.0.0') >= 0 {
+  if versioncmp($facts['munki_version'], '3.3.0') >= 0 {
+    service { 'com.googlecode.munki.appusaged':
+      ensure  => 'running',
+      enable  => true,
+      require => Service['com.googlecode.munki.managedsoftwareupdate-manualcheck']
+    }
+
+    -> exec { 'munki_reload_launchagents':
+      command     => $post_v3_agents_cmd,
+      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+      provider    => 'shell',
+      refreshonly => true,
+      notify      => Exec['munki_app_usage_agent']
+    }
+
+    -> exec {'munki_app_usage_agent':
+      command     => '# get console UID
+  consoleuser=`/usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u`
+
+  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
+  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
+
+  exit 0',
+      path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+      provider    => 'shell',
+      refreshonly => true,
+
+    }
+
+  }
+
+  elsif versioncmp($facts['munki_version'], '3.0.0') >= 0 {
     service { 'com.googlecode.munki.app_usage_monitor':
       ensure  => 'running',
       enable  => true,
@@ -24,19 +69,7 @@ class munki::service {
     }
 
     -> exec { 'munki_reload_launchagents':
-      command     => '# get console UID
-  consoleuser=`/usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u`
-
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
-  /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.managedsoftwareupdate-loginwindow.plist
-  /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.munki-notifier.plist
-
-  exit 0',
+      command     => $post_v3_agents_cmd,
       path        => '/bin:/sbin:/usr/bin:/usr/sbin',
       provider    => 'shell',
       refreshonly => true,

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -56,7 +56,18 @@ class munki::service {
       path        => '/bin:/sbin:/usr/bin:/usr/sbin',
       provider    => 'shell',
       refreshonly => true,
+    }
 
+    exec {'munki unload old app usgae':
+      command     => '/bin/launchctl unload /Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist
+      exit 0',
+      provider    => 'shell',
+      refreshonly => true,
+      before      => File['/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist']
+    }
+
+    -> file {'/Library/LaunchDaemons/com.googlecode.munki.app_usage_monitor.plist':
+      ensure => absent
     }
 
   }


### PR DESCRIPTION
Munki 3.3.0 switches to a new daemon and agent for app usage monitoring.