### PR TITLE
simplified method to find console user id

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@
 class munki::service {
 
   $post_v3_agents_cmd = '# get console UID
-  consoleuser=`/usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u`
+  consoleuser=`/usr/bin/stat -f "%u" /dev/console`
 
   /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
   /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist
@@ -47,7 +47,7 @@ class munki::service {
 
     -> exec {'munki_app_usage_agent':
       command     => '# get console UID
-  consoleuser=`/usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u`
+  consoleuser=`/usr/bin/stat -f "%u" /dev/console`
 
   /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
   /bin/launchctl bootstrap gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.app_usage_monitor.plist
@@ -88,7 +88,7 @@ class munki::service {
   } else {
     exec { 'munki_reload_launchagents':
       command     => '# get console UID
-  consoleuser=`/usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u`
+  consoleuser=`/usr/bin/stat -f "%u" /dev/console`
 
   /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.ManagedSoftwareCenter.plist
   /bin/launchctl bootout gui/$consoleuser /Library/LaunchAgents/com.googlecode.munki.MunkiStatus.plist


### PR DESCRIPTION
Hi,

I've simplified the method where you're figuring out the user id of `/dev/console`.

For reference:
```bash
pwr:~ saitooo$ id
uid=501(saitooo) gid=20(staff) groups=20(staff),702(com.apple.sharepoint.group.2),501(access_bpf),12(everyone),61(localaccounts),79(_appserverusr),80(admin),81(_appserveradm),98(_lpadmin),33(_appstore),100(_lpoperator),204(_developer),250(_analyticsusers),395(com.apple.access_ftp),398(com.apple.access_screensharing),399(com.apple.access_ssh)

pwr:~ saitooo$ /usr/bin/stat -f "%Su" /dev/console | /usr/bin/xargs /usr/bin/id -u
501

pwr:~ saitooo$ /usr/bin/stat -f "%u" /dev/console
501
```

According to the `stat` man page, section `Formats`:
```bash
     datum   A required field specifier, being one of the following:

[..]

             u, g    User ID and group ID of file's owner.
```

Putting the `S` in front of the `u` in the expression represents a string output.