### PR TITLE
Don't always set certificate options

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -57,9 +57,9 @@ class munki::config {
 
   if $software_update_server_url != '' {
     $sus_settings = {'software_update_server_url' => $software_update_server_url}
-    $settings_with_sus_url = merge($cert_settings, $sus_settings)
+    $settings_with_sus_url = merge($settings_with_cert, $sus_settings)
   } else {
-    $settings_with_sus_url = $cert_settings
+    $settings_with_sus_url = $settings_with_cert
   }
 
   if $managed_installs != [] or $managed_uninstalls != [] {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -28,8 +28,6 @@ class munki::config {
   $mcx_settings = {
     'AdditionalHttpHeaders' => $additional_http_headers,
     'AppleSoftwareUpdatesOnly' => $apple_software_updates_only,
-    'ClientCertificatePath' => $client_cert_path,
-    'ClientKeyPath' => $client_key_path,
     'ClientIdentifier' => $client_identifier,
     'DaysBetweenNotifications' => $days_between_notifications,
     'InstallAppleSoftwareUpdates' => $install_apple_software_updates,
@@ -37,7 +35,6 @@ class munki::config {
     'LoggingLevel' => $logging_level,
     'LogToSyslog' => $log_to_syslog,
     'MSULogEnabled' => $msu_log_enabled,
-    'SoftwareRepoCACertificate' => $software_repo_ca_cert,
     'SoftwareRepoURL' => $software_repo_url,
     'SuppressLoginwindowInstall' => $suppress_loginwindow_install,
     'SuppressUserNotification' => $suppress_user_notification,
@@ -51,11 +48,18 @@ class munki::config {
   $managed_installs = lookup('munki::managed_installs', Array, 'unique', [])
   $managed_uninstalls = lookup('munki::managed_uninstalls', Array, 'unique', [])
 
+  if $use_client_cert == true {
+    $cert_settings = {'ClientCertificatePath' => $client_cert_path, 'ClientKeyPath' => $client_key_path, 'SoftwareRepoCACertificate' => $software_repo_ca_cert}
+    $settings_with_cert = merge($mcx_settings, $cert_settings)
+  } else {
+    $settings_with_cert = $mcx_settings
+  }
+
   if $software_update_server_url != '' {
     $sus_settings = {'software_update_server_url' => $software_update_server_url}
-    $settings_with_sus_url = merge($mcx_settings, $sus_settings)
+    $settings_with_sus_url = merge($cert_settings, $sus_settings)
   } else {
-    $settings_with_sus_url = $mcx_settings
+    $settings_with_sus_url = $cert_settings
   }
 
   if $managed_installs != [] or $managed_uninstalls != [] {


### PR DESCRIPTION
Setting a root CA via the command line doesn't work on macOS 11, so we should only set it if is explicitly enabled.