### PR TITLE
suppress max_files warnings

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -20,9 +20,10 @@ class munki::install {
   # Make sure everything is owned by root
   if $facts['munki_dir_exists'] == true {
     file {'/usr/local/munki':
-      owner   => 'root',
-      group   => 'wheel',
-      recurse => true,
+      owner     => 'root',
+      group     => 'wheel',
+      recurse   => true,
+      max_files => -1,
     }
   }
 


### PR DESCRIPTION
Puppet 6 has been EOL since February, 2023, so no reason to not support this option now and prevent warnings being logged. This will close #17.