### PR TITLE
Set default last run times

### DIFF
--- a/lib/facter/munki_last_run.rb
+++ b/lib/facter/munki_last_run.rb
@@ -12,6 +12,6 @@ Facter.add(:munki_last_run) do
       plist = Puppet::Util::Plist.read_plist_file(report_plist)
       last_run = plist["StartTime"]
     end
-    last_run
+    last_run || "never"
   end
 end

--- a/lib/facter/munki_last_run.rb
+++ b/lib/facter/munki_last_run.rb
@@ -6,13 +6,12 @@ report_plist = "/Library/Managed Installs/ManagedInstallReport.plist"
 Facter.add(:munki_last_run) do
   confine kernel: "Darwin"
   setcode do
+    last_run = "never"
     if File.exist?(report_plist)
       require "puppet/util/plist" if Puppet.features.cfpropertylist?
       plist = Puppet::Util::Plist.read_plist_file(report_plist)
       last_run = plist["StartTime"]
-      last_run
-    else
-      "never"
     end
+    last_run
   end
 end

--- a/lib/facter/munki_last_run_unix.rb
+++ b/lib/facter/munki_last_run_unix.rb
@@ -12,6 +12,6 @@ Facter.add(:munki_last_run_unix) do
     else
       last_run = Time.parse(munki_last_run).to_i
     end
-    last_run
+    last_run || 0
   end
 end

--- a/lib/facter/munki_last_run_unix.rb
+++ b/lib/facter/munki_last_run_unix.rb
@@ -10,7 +10,7 @@ Facter.add(:munki_last_run_unix) do
     if munki_last_run == "never"
       last_run = 0
     else
-     last_run = Time.parse(munki_last_run).to_i
+      last_run = Time.parse(munki_last_run).to_i
     end
     last_run
   end

--- a/lib/facter/munki_last_run_unix.rb
+++ b/lib/facter/munki_last_run_unix.rb
@@ -5,11 +5,13 @@ require "time"
 Facter.add(:munki_last_run_unix) do
   confine kernel: "Darwin"
   setcode do
+    last_run = 0
     munki_last_run = Facter.value(:munki_last_run)
     if munki_last_run == "never"
-      0
+      last_run = 0
     else
-      Time.parse(munki_last_run).to_i
+     last_run = Time.parse(munki_last_run).to_i
     end
+    last_run
   end
 end


### PR DESCRIPTION
There are some instances where the report plist can exist, but it doesn't contain the correct values - usually because munki itself is broken. This ensures that we always have a value from these facts.