### PR TITLE
Add Munki 7 Managed Software Center preferences

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -58,3 +58,9 @@ munki::http_password: ''
 munki::munki_python: true
 munki::manage_profile: true
 munki::aggressive_update_notification_days: 14
+munki::msc_offer_to_quit_blocking_apps: false
+munki::msc_offer_to_force_quit_blocking_apps: false
+munki::msc_offer_to_update_others: false
+munki::custom_sidebar_items: []
+munki::download_retries: 0
+munki::download_retry_sleep_seconds: 10

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,6 +26,12 @@ class munki::config {
   $show_optional_installs_for_higher_os_versions = $munki::show_optional_installs_for_higher_os_versions
   $local_only_manifest_name                      = $munki::local_only_manifest_name
   $manage_profile                                = $munki::manage_profile
+  $msc_offer_to_quit_blocking_apps               = $munki::msc_offer_to_quit_blocking_apps
+  $msc_offer_to_force_quit_blocking_apps         = $munki::msc_offer_to_force_quit_blocking_apps
+  $msc_offer_to_update_others                    = $munki::msc_offer_to_update_others
+  $custom_sidebar_items                          = $munki::custom_sidebar_items
+  $download_retries                              = $munki::download_retries
+  $download_retry_sleep_seconds                  = $munki::download_retry_sleep_seconds
 
   $mcx_settings = {
     'AdditionalHttpHeaders' => $additional_http_headers,
@@ -33,10 +39,15 @@ class munki::config {
     'AppleSoftwareUpdatesOnly' => $apple_software_updates_only,
     'ClientIdentifier' => $client_identifier,
     'DaysBetweenNotifications' => $days_between_notifications,
+    'DownloadRetries' => $download_retries,
+    'DownloadRetrySleepSeconds' => $download_retry_sleep_seconds,
     'InstallAppleSoftwareUpdates' => $install_apple_software_updates,
     'UnattendedAppleUpdates' => $unattended_apple_updates,
     'LoggingLevel' => $logging_level,
     'LogToSyslog' => $log_to_syslog,
+    'MSCOfferToQuitBlockingApps' => $msc_offer_to_quit_blocking_apps,
+    'MSCOfferToForceQuitBlockingApps' => $msc_offer_to_force_quit_blocking_apps,
+    'MSCOfferToUpdateOthers' => $msc_offer_to_update_others,
     'MSULogEnabled' => $msu_log_enabled,
     'SoftwareRepoURL' => $software_repo_url,
     'SuppressLoginwindowInstall' => $suppress_loginwindow_install,
@@ -51,11 +62,17 @@ class munki::config {
   $managed_installs = lookup('munki::managed_installs', Array, 'unique', [])
   $managed_uninstalls = lookup('munki::managed_uninstalls', Array, 'unique', [])
 
+  if $custom_sidebar_items != [] {
+    $settings_with_sidebar = merge($mcx_settings, {'CustomSidebarItems' => $custom_sidebar_items})
+  } else {
+    $settings_with_sidebar = $mcx_settings
+  }
+
   if $use_client_cert == true {
     $cert_settings = {'ClientCertificatePath' => $client_cert_path, 'ClientKeyPath' => $client_key_path, 'SoftwareRepoCACertificate' => $software_repo_ca_cert}
-    $settings_with_cert = merge($mcx_settings, $cert_settings)
+    $settings_with_cert = merge($settings_with_sidebar, $cert_settings)
   } else {
-    $settings_with_cert = $mcx_settings
+    $settings_with_cert = $settings_with_sidebar
   }
 
   if $software_update_server_url != '' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,12 @@ class munki (
   Boolean $munki_python,
   Boolean $manage_profile,
   Integer $aggressive_update_notification_days,
+  Boolean $msc_offer_to_quit_blocking_apps,
+  Boolean $msc_offer_to_force_quit_blocking_apps,
+  Boolean $msc_offer_to_update_others,
+  Array $custom_sidebar_items,
+  Integer[0, 10] $download_retries,
+  Integer[1, 30] $download_retry_sleep_seconds,
 )
 {
   class { '::munki::config': }


### PR DESCRIPTION
Expose new Managed Software Center preferences as module parameters and write them into the ManagedInstalls profile:

- `MSCOfferToQuitBlockingApps`, `MSCOfferToForceQuitBlockingApps`, and `MSCOfferToUpdateOthers`: Booleans (default `false`) controlling how MSC handles applications that block pending updates.
- `CustomSidebarItems`: an Array of hashes (default empty) for adding custom entries to the MSC sidebar; each element has `title`, `icon`, and `page` keys and serializes into the profile as an array of dicts.
- `DownloadRetries` (`Integer[0, 10]`, default `0`) and `DownloadRetrySleepSeconds` (`Integer[1, 30]`, default `10`): control how failed downloads are retried, with the valid ranges enforced by the parameter types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)